### PR TITLE
Update talos-bootstrap - missing disk info

### DIFF
--- a/talos-bootstrap
+++ b/talos-bootstrap
@@ -341,6 +341,11 @@ fi
 default_k8s_endpoint="${CONFIG_KUBERNETES_API_ENDPOINT:-https://${vip_address:-${address}}:6443}"
 k8s_endpoint=$(dialog --keep-tite --title talos-bootstrap --inputbox "Enter Kubernetes endpoint:" 8 40 "${default_k8s_endpoint}" 3>&1 1>&2 2>&3) || exit 0
 
+# Workaround - no disk found - assume sda
+if ["" = $disk]; then
+  disk="sda"
+fi
+
 # Generating config patch...
 machine_config=$(cat <<EOT
 machine:


### PR DESCRIPTION
Assume sda as disk if no disk can be found.

Fixes install issues with Hyper-V.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced system reliability by automatically assigning a default disk when none is detected. This fallback mechanism ensures that configuration and bootstrapping processes run smoothly, preventing potential interruptions and providing a more robust and stable user experience without requiring any manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->